### PR TITLE
Improve Apple-like aesthetics

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,9 +25,9 @@
     --nav-blur-saturate: blur(20px) saturate(180%);
     --nav-height: 70px; /* Adjust as needed by inspecting your nav */
 
-    --hero-bg-color: #1c1c1e;
-    --hero-text-color: #fff;
-    --hero-subtitle-color: #d1d1d6;
+    --hero-bg: linear-gradient(180deg, #fbfbfd 0%, #f5f5f7 100%);
+    --hero-text-color: #1d1d1f;
+    --hero-subtitle-color: #6e6e73;
 
     --icon-placeholder-bg: #007aff30; /* For feature icons etc. */
     --icon-placeholder-color: #007aff;
@@ -98,7 +98,7 @@ html.dark-mode {
     --nav-bg-color: rgba(28, 28, 30, 0.75);
     --nav-border-color: rgba(84,84,88,0.65); 
 
-    --hero-bg-color: #000;
+    --hero-bg: linear-gradient(180deg, #1c1c1e 0%, #000 100%);
     --hero-text-color: #fff;
     --hero-subtitle-color: #a0a0a5;
 
@@ -155,7 +155,7 @@ body {
     visibility: hidden;
     opacity: 0;
     margin: 0; padding: 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     line-height: 1.6;
     scroll-behavior: smooth;
     overflow-x: hidden;
@@ -225,10 +225,11 @@ nav ul li a {
     color: var(--link-color);
     font-weight: 500;
     font-size: 0.95em;
+    letter-spacing: 0.02em;
     transition: color 0.3s ease, opacity 0.3s ease;
     position: relative;
     opacity: 0.9;
-    white-space: nowrap; 
+    white-space: nowrap;
 }
 nav ul li a:hover { color: var(--link-hover-color); opacity: 1; }
 nav ul li a::after {
@@ -263,7 +264,7 @@ nav ul li a:hover::after { transform: scaleX(1); transform-origin: bottom left; 
 /* Hero Section */
 .hero {
     text-align: center; padding: 120px 20px 100px;
-    background-color: var(--hero-bg-color);
+    background: var(--hero-bg);
     position: relative; color: var(--hero-text-color);
 }
 .hero h1 {
@@ -287,7 +288,7 @@ nav ul li a:hover::after { transform: scaleX(1); transform-origin: bottom left; 
     font-size: 1.05em; font-weight: 500;
     color: #fff;
     text-decoration: none; text-align: center;
-    border-radius: 10px; cursor: pointer; border: none;
+    border-radius: 12px; cursor: pointer; border: none;
     transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
 }
 .hero .cta-button {
@@ -389,7 +390,7 @@ nav ul li a:hover::after { transform: scaleX(1); transform-origin: bottom left; 
 }
 .feature-item, .future-mode-item {
     padding: 35px;
-    border-radius: 12px;
+    border-radius: 20px;
     width: 100%; max-width: 320px;
     box-shadow: 0 5px 15px var(--card-shadow);
     text-align: left;
@@ -405,12 +406,12 @@ nav ul li a:hover::after { transform: scaleX(1); transform-origin: bottom left; 
 .feature-item .icon-placeholder {
     background-color: var(--icon-placeholder-bg); color: var(--icon-placeholder-color);
     width: 48px; height: 48px; margin-bottom: 20px; display: flex; align-items: center; justify-content: center;
-    border-radius: 10px; font-size: 24px;
+    border-radius: 14px; font-size: 24px;
 }
 .future-mode-item .icon-placeholder {
     background-color: var(--future-icon-placeholder-bg); color: var(--future-icon-placeholder-color);
     width: 48px; height: 48px; margin-bottom: 20px; display: flex; align-items: center; justify-content: center;
-    border-radius: 10px; font-size: 24px;
+    border-radius: 14px; font-size: 24px;
 }
 .feature-item .icon-placeholder img, .feature-item .icon-placeholder svg,
 .future-mode-item .icon-placeholder img, .future-mode-item .icon-placeholder svg { width: 28px; height: 28px; }


### PR DESCRIPTION
## Summary
- switch hero section to a light gradient in light mode
- adjust dark mode hero background
- add SF Pro fonts and tweak nav link spacing
- soften button and card corners

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68414bc894748327b82b1bd3a6ae682d