### PR TITLE
Update site styling to Apple-inspired colors

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found - NexCore</title>
     <link rel="icon" href="/assets/images/favicon.png" type="image/png">
-    <meta name="theme-color" content="#007aff">
+    <meta name="theme-color" content="#0071e3">
     <script>
       (function() {
         try {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>NexCore - Your Next Minecraft Adventure</title>
     <link rel="icon" href="/assets/images/favicon.png" type="image/png">
     <meta name="description" content="Join NexCore, your ultimate Minecraft server adventure! Experience unique gamemodes, an active community, and lag-free performance. Start your journey today!">
-    <meta name="theme-color" content="#007aff">
+    <meta name="theme-color" content="#0071e3">
     <meta property="og:title" content="NexCore - Your Next Minecraft Adventure">
     <meta property="og:description" content="Join NexCore, your ultimate Minecraft server adventure! Experience unique gamemodes, an active community, and lag-free performance. Start your journey today!">
     <meta property="og:image" content="https://nexcore.top/assets/images/nexcore-icon.png">

--- a/style.css
+++ b/style.css
@@ -5,11 +5,11 @@
     --text-muted-color: #6e6e73;
     --heading-color: #1d1d1f;
     --link-color: #1d1d1f; /* Nav link color */
-    --link-hover-color: #007aff;
-    --primary-accent-color: #007aff;
-    --primary-accent-hover-bg: #0068d6;
-    --primary-accent-shadow: rgba(0, 122, 255, 0.25);
-    --primary-accent-hover-shadow: rgba(0, 122, 255, 0.35);
+    --link-hover-color: #0071e3;
+    --primary-accent-color: #0071e3;
+    --primary-accent-hover-bg: #005bb5;
+    --primary-accent-shadow: rgba(0, 113, 227, 0.25);
+    --primary-accent-hover-shadow: rgba(0, 113, 227, 0.35);
 
     --section-bg: #fff;
     --section-alt-bg: #f5f5f7;
@@ -29,19 +29,19 @@
     --hero-text-color: #1d1d1f;
     --hero-subtitle-color: #6e6e73;
 
-    --icon-placeholder-bg: #007aff30; /* For feature icons etc. */
-    --icon-placeholder-color: #007aff;
+    --icon-placeholder-bg: #0071e330; /* For feature icons etc. */
+    --icon-placeholder-color: #0071e3;
     --future-icon-placeholder-bg: #7857fe30;
     --future-icon-placeholder-color: #7857fe;
 
-    --join-section-bg: #007aff;
+    --join-section-bg: #0071e3;
     --join-section-text: #fff;
     --join-section-subheading-text: rgba(255,255,255,0.85);
     --ip-display-bg: rgba(255, 255, 255, 0.15);
     --ip-display-border: rgba(255, 255, 255, 0.3);
     --ip-display-text: #fff;
     --copy-btn-bg: #fff;
-    --copy-btn-text: #007aff;
+    --copy-btn-text: #0071e3;
     --copy-btn-hover-bg: #e9e9ed;
     --copy-btn-copied-bg: #34c759;
     --copy-btn-copied-text: #fff;
@@ -54,7 +54,7 @@
 
     --footer-bg: #1d1d1f;
     --footer-text: #a0a0a5;
-    --footer-link: #2997ff;
+    --footer-link: #0071e3;
     --footer-links-color: #b0b0b5;
     --footer-links-hover-color: #fff;
 
@@ -268,8 +268,11 @@ nav ul li a:hover::after { transform: scaleX(1); transform-origin: bottom left; 
     position: relative; color: var(--hero-text-color);
 }
 .hero h1 {
-    font-size: 3.8em; font-weight: 700; color: var(--hero-text-color);
-    margin-bottom: 0.3em; letter-spacing: -0.02em;
+    font-size: 4.5em;
+    font-weight: 600;
+    color: var(--hero-text-color);
+    margin-bottom: 0.3em;
+    letter-spacing: -0.015em;
     opacity: 0; transform: translateY(20px);
     animation: fadeInUp 0.8s 0.2s ease-out forwards;
 }
@@ -548,7 +551,7 @@ footer a:hover { text-decoration: underline; }
     }
 
     /* Other Responsive Styles */
-    .hero h1 { font-size: 2.8em; }
+    .hero h1 { font-size: 3.2em; }
     .hero .subtitle { font-size: 1.3em; }
     .section h2, .rules-content h1, .legal-content h1, .guide-content h1 { font-size: 2.2em; letter-spacing: -0.01em; }
     .legal-content h2, .guide-content h2 { font-size: 1.7em; } 


### PR DESCRIPTION
## Summary
- adopt Apple's blue (`#0071e3`) as the primary accent
- tweak hero heading to use larger typography
- update meta theme colors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841d6ab71288327bed734017e9b235b