### PR TITLE
Fix server status player count

### DIFF
--- a/script.js
+++ b/script.js
@@ -201,7 +201,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (data && data.online) {
                     let playerInfo = '';
                     if (data.players && typeof data.players.online === 'number') {
-                        playerInfo = ` - ${data.players.online}/${data.players.max} players`;
+                        playerInfo = ` - ${data.players.online}`;
+                        if (typeof data.players.max === 'number') {
+                            playerInfo += `/${data.players.max}`;
+                        }
+                        playerInfo += ' players';
                     }
                     statusEl.innerHTML = `Status: <span class="status-online">Online</span>${playerInfo}`;
                 } else {


### PR DESCRIPTION
## Summary
- handle missing `max` data from server status API so we don't show `undefined`

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6843ff7953ec8327b8ef0b733a3854e8