### PR TITLE
Fix mobile navigation menu not showing links

### DIFF
--- a/script.js
+++ b/script.js
@@ -51,6 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const closeMenu = () => {
             navLinksWrapper.classList.remove('nav-open');
             navOverlay.classList.remove('visible');
+            document.body.classList.remove('menu-open');
             mobileNavToggle.setAttribute('aria-expanded', 'false');
             const iconSpan = mobileNavToggle.querySelector('span');
             if (iconSpan) {
@@ -66,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 iconSpan.textContent = isOpen ? '✕' : '☰';
             }
             navOverlay.classList.toggle('visible', isOpen);
+            document.body.classList.toggle('menu-open', isOpen);
         });
 
         navOverlay.addEventListener('click', closeMenu);

--- a/style.css
+++ b/style.css
@@ -683,6 +683,10 @@ footer a:hover { text-decoration: underline; }
     /* Mobile Navigation Specifics */
     .mobile-nav-toggle { display: block; }
 
+    body.menu-open {
+        overflow: hidden;
+    }
+
     .nav-overlay {
         display: none;
         position: fixed;
@@ -700,9 +704,9 @@ footer a:hover { text-decoration: underline; }
     .nav-links-wrapper {
         position: fixed;
         top: 0;
-        right: -100%;
+        right: 0;
         bottom: 0;
-        width: 80%;
+        width: 80vw;
         max-width: 300px;
         background-color: var(--nav-bg-color);
         box-shadow: -2px 0 10px rgba(0,0,0,0.1);
@@ -713,10 +717,11 @@ footer a:hover { text-decoration: underline; }
         padding-left: 20px;
         padding-right: 20px;
         overflow-y: auto;
-        transition: right 0.3s ease;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
         z-index: 1000;
     }
-    .nav-links-wrapper.nav-open { right: 0; }
+    .nav-links-wrapper.nav-open { transform: translateX(0); }
 
     nav ul {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- fix mobile nav transform for reliable slide-in
- prevent background scrolling when menu is open
- toggle class on body from script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486e7c8e44832785d900890825042e