### PR TITLE
Fix initial page load flash

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,12 +21,18 @@
     <style>
       html { background-color: #f5f5f7; color: #1d1d1f; }
       html.dark-mode { background-color: #161617; color: #f5f7fa; }
-      body { visibility: hidden; opacity: 0; }
+      .preload { visibility: hidden; opacity: 0; }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 </head>
-<body>
+<body class="preload">
 <nav>
     <div class="container">
         <a href="index.html" class="logo">

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -29,17 +29,23 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
         /* background-color is inherited from html or set by html.dark-mode */
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 </head>
-<body>
+<body class="preload">
 
     <nav>
         <div class="container">

--- a/dynmap.html
+++ b/dynmap.html
@@ -29,18 +29,24 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
         /* background-color is inherited from html or set by html.dark-mode */
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 
 </head>
-<body>
+<body class="preload">
 
   <nav>
         <div class="container">

--- a/faq.html
+++ b/faq.html
@@ -29,16 +29,22 @@
         background-color: #161617;
         color: #f5f7fa;
       }
-      body {
+      .preload {
         visibility: hidden;
         opacity: 0;
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 </head>
-<body>
+<body class="preload">
 
     <nav>
         <div class="container">

--- a/guide.html
+++ b/guide.html
@@ -29,16 +29,22 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 </head>
-<body>
+<body class="preload">
 
     <nav>
         <div class="container">

--- a/index.html
+++ b/index.html
@@ -35,17 +35,23 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
         /* background-color is inherited from html or set by html.dark-mode */
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 </head>
-<body>
+<body class="preload">
 
 <nav>
     <div class="container">

--- a/privacy.html
+++ b/privacy.html
@@ -29,18 +29,24 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
         /* background-color is inherited from html or set by html.dark-mode */
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 
 </head>
-<body>
+<body class="preload">
 
     <nav>
         <div class="container">

--- a/rules.html
+++ b/rules.html
@@ -29,18 +29,24 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
         /* background-color is inherited from html or set by html.dark-mode */
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 
 </head>
-<body>
+<body class="preload">
 
     <nav>
         <div class="container">

--- a/script.js
+++ b/script.js
@@ -233,5 +233,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // The inline script in <head> handles initial theme class on <html>
     // This ensures body becomes visible
     document.body.classList.add('loaded');
+    document.body.classList.remove('preload');
 
 });

--- a/style.css
+++ b/style.css
@@ -151,7 +151,7 @@ html {
     color: var(--text-color);
     transition: background-color 0.3s ease, color 0.3s ease;
 }
-body {
+body.preload {
     visibility: hidden;
     opacity: 0;
     margin: 0; padding: 0;

--- a/terms.html
+++ b/terms.html
@@ -29,18 +29,24 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
         /* background-color is inherited from html or set by html.dark-mode */
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 
 </head>
-<body>
+<body class="preload">
 
     <nav>
         <div class="container">

--- a/whitelist.html
+++ b/whitelist.html
@@ -29,18 +29,24 @@
         background-color: #161617; 
         color: #f5f7fa;       
       }
-      body {
+      .preload {
         visibility: hidden; /* Hide body initially to prevent flash */
         opacity: 0;
         /* background-color is inherited from html or set by html.dark-mode */
       }
     </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        document.body.classList.add("loaded");
+        document.body.classList.remove("preload");
+      });
+    </script>
 
     <link rel="stylesheet" href="style.css">
 <noscript><style>body{visibility:visible;opacity:1}</style></noscript>
 
 </head>
-<body>
+<body class="preload">
 
     <nav>
         <div class="container">


### PR DESCRIPTION
## Summary
- adjust FOUC handling by hiding body with `.preload` class
- add fallback inline script to reveal the page
- update global stylesheet and JavaScript to support the preload class

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68487bf800cc8327a6594bd065bccaa6